### PR TITLE
draft: Set showcase in modal

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -17,6 +17,7 @@ export interface Handout {
   id: string;
   name: string;
   url: string;
+  isShowcaseView?: boolean;
 }
 
 export interface Adventure {

--- a/src/designSystem/components/Modal/Modal.css
+++ b/src/designSystem/components/Modal/Modal.css
@@ -25,3 +25,10 @@
   width: 700px;
   z-index: var(--z-index-modal);
 }
+
+.showcase {
+  height: fit-content;
+  width: fit-content;
+  overflow-y: unset;
+  max-height: unset;
+}

--- a/src/designSystem/components/Modal/Modal.tsx
+++ b/src/designSystem/components/Modal/Modal.tsx
@@ -13,13 +13,15 @@ export interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   portalElement: HTMLElement;
+  isShowcaseView?: boolean;
 }
 
 export const Modal = ({
   children,
   isOpen,
   onClose,
-  portalElement
+  portalElement,
+  isShowcaseView
 }: ModalProps) => {
   useEffect(() => {
     if (isOpen) {
@@ -40,7 +42,7 @@ export const Modal = ({
 
   const modal = (
     <>
-      <div className="dm-screen-design-system-modal">
+      <div className={`dm-screen-design-system-modal ${isShowcaseView ? "showcase": ""}`}>
         {children}
       </div>
       <div

--- a/src/dm-screen/components/PlayerView/PlayerView.tsx
+++ b/src/dm-screen/components/PlayerView/PlayerView.tsx
@@ -157,6 +157,7 @@ export const PlayerView = () => {
                 setImageToDisplay(null);
               }}
               portalElement={document.body}
+              isShowcaseView={true}
               >
               <img
                 alt={imageToDisplay.description}


### PR DESCRIPTION
Sets showcase mode to true at the moment. The modal in the player side will reflect size of content