### PR TITLE
132 orchestration of avatar stacking

### DIFF
--- a/src/designSystem/components/CircleBadgeForm/CircleBadgeForm.css
+++ b/src/designSystem/components/CircleBadgeForm/CircleBadgeForm.css
@@ -5,8 +5,8 @@
   box-shadow: var(--base-shadow);
   cursor: pointer;
   display: flex;
-  height: 30px;
-  width: 30px;
+  height: 20px;
+  width: 20px;
 }
 
 .dm-screen-design-system-circle-badge-form input {
@@ -14,7 +14,7 @@
   border: none;
   color: var(--white);
   font-family: var(--base-font-family);
-  font-size: var(--sub-font-size);
+  font-size: 10px;
   font-weight: var(--font-weight-regular);
   outline: none;
   text-align: center;

--- a/src/designSystem/components/Tooltip/Tooltip.css
+++ b/src/designSystem/components/Tooltip/Tooltip.css
@@ -7,13 +7,14 @@
 }
 
 .dm-screen-design-system-tooltip-content {
-  background-color: var(--green-50);
-  border: solid 2px var(--green-100);
+  background-color: var(--black-50);
+  border: solid 2px var(--black-300);
   border-radius: var(--border-radius);
-  padding: var(--spacing-small);
+  padding: 6px;
 }
 
 .dm-screen-design-system-tooltip-content * {
+  font-size: var(--sub-font-size);
   margin: 0;
 }
 
@@ -23,67 +24,138 @@
   width: 0; 
 }
 
+.dm-screen-design-system-tooltip-arrow-small {
+  height: 0;
+  position: absolute;
+  width: 0; 
+  z-index: 1;
+}
+
 .dm-screen-design-system-tooltip-arrow-down {
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid var(--green-100);
+  border-top: 8px solid var(--black-300);
   bottom: -8px;
   left: calc(50% - 8px);
+}
+
+.dm-screen-design-system-tooltip-arrow-small-down {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid var(--black-50);
+  bottom: -4px;
+  left: calc(50% - 6px);
 }
 
 .dm-screen-design-system-tooltip-arrow-down-left {
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid var(--green-100);
-  left: 8px;
+  border-top: 8px solid var(--black-300);
   bottom: -8px;
+  left: 8px;
+}
+
+.dm-screen-design-system-tooltip-arrow-small-down-left {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid var(--black-50);
+  bottom: -4px;
+  left: 10px;
 }
 
 .dm-screen-design-system-tooltip-arrow-down-right {
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid var(--green-100);
-  right: 8px;
+  border-top: 8px solid var(--black-300);
   bottom: -8px;
+  right: 8px;
+}
+
+.dm-screen-design-system-tooltip-arrow-small-down-right {
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid var(--black-50);
+  bottom: -4px;
+  right: 10px;
 }
 
 .dm-screen-design-system-tooltip-arrow-left {
   border-bottom: 8px solid transparent;
-  border-right: 8px solid var(--green-100);
+  border-right: 8px solid var(--black-300);
   border-top: 8px solid transparent;
   left: -8px;
   top: calc(50% - 8px);
 }
 
+.dm-screen-design-system-tooltip-arrow-small-left {
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid var(--black-50);;
+  border-top: 6px solid transparent;
+  left: -4px;
+  top: calc(50% - 6px);
+}
+
 .dm-screen-design-system-tooltip-arrow-right {
   border-bottom: 8px solid transparent;
-  border-left: 8px solid var(--green-100);
+  border-left: 8px solid var(--black-300);
   border-top: 8px solid transparent;
   right: -8px;
   top: calc(50% - 8px);
 }
 
+.dm-screen-design-system-tooltip-arrow-small-right {
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid var(--black-50);;
+  border-top: 6px solid transparent;
+  right: -4px;
+  top: calc(50% - 6px);
+}
+
 .dm-screen-design-system-tooltip-arrow-up {
-  border-bottom: 8px solid var(--green-100);
+  border-bottom: 8px solid var(--black-300);
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
   left: calc(50% - 8px);
   top: -8px;
 }
 
+.dm-screen-design-system-tooltip-arrow-small-up {
+  border-bottom: 8px solid var(--black-50);
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  left: calc(50% - 8px);
+  top: -4px;
+}
+
 .dm-screen-design-system-tooltip-arrow-up-left {
-  border-bottom: 8px solid var(--green-100);
+  border-bottom: 8px solid var(--black-300);
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
   left: 8px;
   top: -8px;
 }
 
+.dm-screen-design-system-tooltip-arrow-small-up-left {
+  border-bottom: 8px solid var(--black-50);
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  left: 8px;
+  top: -4px;
+}
+
 .dm-screen-design-system-tooltip-arrow-up-right {
-  border-bottom: 8px solid var(--green-100);
+  border-bottom: 8px solid var(--black-300);
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
   right: 8px;
   top: -8px;
+}
+
+.dm-screen-design-system-tooltip-arrow-small-up-right {
+  border-bottom: 8px solid var(--black-50);
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  right: 8px;
+  top: -4px;
 }
 

--- a/src/dm-screen/components/InitiativeCard/InitiativeCard.css
+++ b/src/dm-screen/components/InitiativeCard/InitiativeCard.css
@@ -16,6 +16,21 @@
   width: 120px;
 }
 
+.initiative-card-resource-bubbles {
+  bottom: 30px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 4px;
+  position: absolute;
+  width: 100%;
+}
+
+.initiative-card-statuses {
+  position: relative;
+  top: 4px;
+}
+
 .initiative-card-gm-only {
   border: solid 4px var(--blue-50);
   opacity: 0.4;
@@ -32,12 +47,6 @@
   visibility: hidden;
 }
 
-.initiative-card-ac {
-  bottom: 38px;
-  left: 8px;
-  position: absolute;
-}
-
 .initiative-card-character-name {
   background-color: rgba(0, 0, 0, 0.5);
   bottom: 0;
@@ -51,16 +60,4 @@
   position: absolute;
   text-align: center;
   width: 100%;
-}
-
-.initiative-card-hp {
-  bottom: 38px;
-  position: absolute;
-  right: 8px;
-}
-
-.initiative-card-initiative-roll {
-  position: absolute;
-  right: 8px;
-  top: 8px;
 }

--- a/src/dm-screen/components/InitiativeCard/InitiativeCard.css
+++ b/src/dm-screen/components/InitiativeCard/InitiativeCard.css
@@ -17,7 +17,7 @@
 }
 
 .initiative-card-resource-bubbles {
-  bottom: 30px;
+  bottom: 34px;
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
@@ -57,7 +57,10 @@
   line-height: 1;
   margin: 0;
   padding: 8px;
+  overflow: hidden;
   position: absolute;
   text-align: center;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
   width: 100%;
 }

--- a/src/dm-screen/components/InitiativeCard/InitiativeCard.tsx
+++ b/src/dm-screen/components/InitiativeCard/InitiativeCard.tsx
@@ -1,7 +1,10 @@
 import { CircleBadgeForm } from '@designSystem/components';
 import classNames from 'classnames';
+import { StatusEffects } from '@rules/enums';
 import { useCallback } from 'react';
 import { VisibilityState } from '@core/types';
+
+import { StatusAvatarCollection } from '../StatusAvatar/StatusAvatarCollection';
 
 import './InitiativeCard.css';
 
@@ -18,6 +21,7 @@ export interface InitiativeCardProps {
   resourceA: number;
   resourceB: number;
   sortValue: number;
+  statuses: StatusEffects[];
   visibilityState: VisibilityState;
 }
 
@@ -34,6 +38,7 @@ export const InitiativeCard = ({
   resourceA,
   resourceB,
   sortValue,
+  statuses,
   visibilityState
 }: InitiativeCardProps) => {
   const isNum = useCallback((value: string): boolean => {
@@ -67,7 +72,14 @@ export const InitiativeCard = ({
       data-test-id="initiative-card"
       onDoubleClick={internalOnDoubleClick}
       style={styles}>
-      <div className="initiative-card-initiative-roll">
+      {
+        statuses.length ? (
+          <div className="initiative-card-statuses">
+            <StatusAvatarCollection statuses={statuses}/>
+          </div>
+        ) : null
+      }
+      <div className="initiative-card-resource-bubbles">
         <CircleBadgeForm
           color="orange"
           onChange={(value) => {
@@ -76,18 +88,6 @@ export const InitiativeCard = ({
           onValidate={isNum}
           value={String(sortValue)}
         />
-      </div>
-      <div className="initiative-card-ac">
-        <CircleBadgeForm
-          color="blue"
-          onChange={(value) => {
-            onResourceAChange(Number(value) ?? 0);
-          }}
-          onValidate={isNum}
-          value={String(resourceA)}
-        />
-      </div>
-      <div className="initiative-card-hp">
         <CircleBadgeForm
           color="green"
           onChange={(value) => {
@@ -95,6 +95,14 @@ export const InitiativeCard = ({
           }}
           onValidate={isNum}
           value={String(resourceB)}
+        />
+        <CircleBadgeForm
+          color="blue"
+          onChange={(value) => {
+            onResourceAChange(Number(value) ?? 0);
+          }}
+          onValidate={isNum}
+          value={String(resourceA)}
         />
       </div>
       <p className="initiative-card-character-name">

--- a/src/dm-screen/components/InitiativeOrderComponent/InitiativeOrderComponent.tsx
+++ b/src/dm-screen/components/InitiativeOrderComponent/InitiativeOrderComponent.tsx
@@ -176,6 +176,7 @@ export const InitiativeOrderComponent = ({
                   resourceA={item.resourceA}
                   resourceB={item.resourceB}
                   sortValue={item.sortValue}
+                  statuses={[]}
                   visibilityState={item.visibilityState}
                 />
               );

--- a/src/dm-screen/components/StatusAvatar/StatusAvatar.css
+++ b/src/dm-screen/components/StatusAvatar/StatusAvatar.css
@@ -5,8 +5,10 @@
   border-radius: 50%;
   cursor: pointer;
   display: flex;
-  font-size: 18px;
-  height: 40px;
+  font-size: 14px;
+  height: 24px;
   justify-content: center;
-  width: 40px;
+  min-height: 24px;
+  min-width: 24px;
+  width: 24px;
 }

--- a/src/dm-screen/components/StatusAvatar/StatusAvatar.tsx
+++ b/src/dm-screen/components/StatusAvatar/StatusAvatar.tsx
@@ -3,8 +3,8 @@ import { StatusEffects } from '@rules/enums';
 import { Tooltip } from '@designSystem/components';
 
 export interface StatusAvatarProps {
-  status: StatusEffects,
-  zIndex: number,
+  status: StatusEffects;
+  zIndex: number;
 }
 
 export const StatusAvatar = ({

--- a/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.css
+++ b/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.css
@@ -1,0 +1,15 @@
+.status-avatar-collection {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+
+.status-avatar-collection .status-avatar:not(:last-of-type) {
+  margin-left: calc(-1 *var(--spacing-small));
+}
+
+.status-avatar-collection.status-avatar-collection-crowded .status-avatar:not(:last-of-type) {
+  margin-left: -18px;
+}

--- a/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.stories.tsx
+++ b/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.stories.tsx
@@ -1,22 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { InitiativeCard } from './InitiativeCard';
+import { StatusAvatarCollection } from './StatusAvatarCollection';
 import { StatusEffects } from '../../../../rules/enums';
 
 const meta = {
-  title: 'dm-screen/InitiativeCard',
-  component: InitiativeCard,
+  title: 'Dm-Screen/StatusAvatarCollection',
+  component: StatusAvatarCollection,
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {
 
-  },
-  args: {
-
   }
-} satisfies Meta<typeof InitiativeCard>;
+} satisfies Meta<typeof StatusAvatarCollection>;
 
 export default meta;
 
@@ -24,15 +21,17 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    name: 'John Doe',
-    resourceA: 15,
-    resourceB: 374,
-    sortValue: 20,
     statuses: [
       StatusEffects.BLINDED,
       StatusEffects.CHARMED,
       StatusEffects.DEAFENED,
-      StatusEffects.EXHAUSTION
+      StatusEffects.EXHAUSTION,
+      StatusEffects.FRIGHTENED,
+      StatusEffects.FRIGHTENED,
+      StatusEffects.FRIGHTENED,
+      StatusEffects.FRIGHTENED,
+      StatusEffects.FRIGHTENED,
+      StatusEffects.FRIGHTENED
     ]
   }
 };

--- a/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.tsx
+++ b/src/dm-screen/components/StatusAvatar/StatusAvatarCollection.tsx
@@ -1,0 +1,37 @@
+import classNames from 'classnames';
+import { StatusEffects } from '@rules/enums';
+
+import { StatusAvatar } from "./StatusAvatar";
+
+import './StatusAvatarCollection.css';
+
+export interface StatusAvatarCollectionProps {
+  statuses: StatusEffects[];
+}
+
+export const StatusAvatarCollection = ({
+  statuses
+}: StatusAvatarCollectionProps) => {
+  const crowdedThreshold = 4;
+  const displayedThreshold = 8;
+  
+  const classList = {
+    'status-avatar-collection': true,
+    'status-avatar-collection-crowded': statuses.length > crowdedThreshold
+  };
+
+  return (
+    <div className={classNames(classList)}>
+      {
+        statuses.map((status, index) => {
+          return index < displayedThreshold ? (
+            <StatusAvatar
+              status={status}
+              zIndex={index}
+            />
+          ) : null;
+        })
+      }
+    </div>
+  );
+};


### PR DESCRIPTION
Changes:

- Added StatusAvatarCollection component
- Added StatusAvatarCollection  to the top of the initiative card
- Added a statuses prop to the initiative card
- Moved the ac/hp/initiative inputs to the bottom, above the creature name
- Added text overflow and ellipses to imitative card name box, to prevent overlap with inputs
- Adjusted sizing of all inputs and status avatars to make them fit in the initiative card, also to support 3 digit inputs
- Added better arrow styling for tooltip
- Made tooltip color more neutral to not conflict with "success" button colors

<img width="263" alt="on-page" src="https://github.com/user-attachments/assets/c2281c49-b1c2-4586-948d-db0ab34876e3">

<img width="165" alt="in-story" src="https://github.com/user-attachments/assets/d34e8437-84eb-4644-9177-8ab7fa876bb3">

<img width="169" alt="in-story-crowded" src="https://github.com/user-attachments/assets/24c3105a-2cdb-477b-9fc1-0bca53c5acd8">



